### PR TITLE
Remove debug logging from BodyViewer

### DIFF
--- a/src/components/BodyViewer.jsx
+++ b/src/components/BodyViewer.jsx
@@ -19,8 +19,8 @@ export default function BodyViewer({ raw = '', transport = 0 }) {
   }, [raw, delta]);
 
   // justo antes del return
-console.log('RAW length:', raw?.length)      // ¿llega texto?
-console.log('HTML preview:', html.slice(0,200)) // primeros 2
+  // console.log('RAW length:', raw?.length)      // ¿llega texto?
+  // console.log('HTML preview:', html.slice(0,200)) // primeros 2
 
   return (
     <>


### PR DESCRIPTION
## Summary
- comment out leftover debug console logging in `BodyViewer`

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887b1bf31ac832f9a7d4538de79418e