### PR TITLE
Remove duplicate manifest

### DIFF
--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,1 +1,0 @@
-{"name":"","short_name":"","icons":[{"src":"/android-chrome-192x192.png","sizes":"192x192","type":"image/png"},{"src":"/android-chrome-512x512.png","sizes":"512x512","type":"image/png"}],"theme_color":"#ffffff","background_color":"#ffffff","display":"standalone"}


### PR DESCRIPTION
## Summary
- delete `public/site.webmanifest` since VitePWA already defines a manifest in `astro.config.mjs`

## Testing
- `npm install` *(fails: ENOTFOUND)*

------
https://chatgpt.com/codex/tasks/task_e_6887b1e35394832fa9765d844a4b38ac